### PR TITLE
build: fix sonarcloud workflow configuration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,7 +40,7 @@ jobs:
         if: env.SONAR_TOKEN != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.host.url="${{ vars.SONAR_HOST_URL }}" /d:sonar.cs.cobertura.reportsPaths=coverage/**/coverage.cobertura.xml /d:sonar.qualitygate.wait=true
+        run: dotnet sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.host.url="${{ vars.SONAR_HOST_URL }}" /d:sonar.cs.cobertura.reportsPaths="coverage/**/coverage.cobertura.xml"
       - name: Build
         run: dotnet build CommentSense.slnx --configuration Release
       - name: Test


### PR DESCRIPTION
Remove sonar.qualitygate.wait parameter to prevent blocking and quote the coverage reports path to ensure correct glob expansion.